### PR TITLE
move logic to window proxy

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -3,21 +3,21 @@ name: Test and Coverage
 on:
   push:
     branches:
-    - stable
-    - main
+      - stable
+      - main
   pull_request:
     branches:
-    - stable
-    - main
+      - stable
+      - main
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Log level'     
+        description: "Log level"
         required: true
-        default: 'warning'
+        default: "warning"
 jobs:
   test:
-    environment: CI 
+    environment: CI
     name: Node.js v${{ matrix.nodejs }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -25,25 +25,25 @@ jobs:
       matrix:
         nodejs: [16, 17]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.nodejs }}
-    - uses: pnpm/action-setup@v2.0.1
-      with:
-        version: 6.24.1
-    - name: Install
-      run: |
-        pnpm install
-        pnpm install -g c8@7
-    - name: Generate coverage
-      if: matrix.nodejs >= 17
-      run: |
-        c8 --src src pnpm test
-        c8 report -r json
-    - uses: codecov/codecov-action@v2
-      if: matrix.nodejs >= 17
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        directory: coverage
-        verbose: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.nodejs }}
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.24.1
+      - name: Install
+        run: |
+          pnpm install
+          pnpm install -g c8@7
+      - name: Generate coverage
+        if: matrix.nodejs >= 17
+        run: |
+          c8 --src src pnpm test
+          c8 report -r json
+      - uses: codecov/codecov-action@v2
+        if: matrix.nodejs >= 17
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: coverage
+          verbose: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,132 +1,25 @@
-import { createHashHistory, createPath } from "history";
+import { createHashHistory } from "history";
+import { useTranscoders } from "./transcoder";
+import { useWrappers, inWrappers, getProperty } from "./wrapper";
+import { wrapWarn } from "./warn";
+
+// Exports to remove in next major release
+export { useHashParser } from "./transcoder";
+export { useWrappers } from "./wrapper";
+export { useParser } from "./parser";
+
+// Type exports to remove in next major release
+export type { GoAPI, ListenAPI } from "./legacy";
+export type { WrapperOptions } from "./wrapper";
+export type { UseParser, Parser } from "./parser";
 
 // Types
-import type {
-  To,
-  Path,
-  Hash,
-  Pathname,
-  Update,
-  History,
-  Listener,
-  Location,
-} from "history";
-
-type VoidFn = () => void;
-type Pair = [string, string];
-type PathRenamer = (p: Pathname) => Pathname;
-type Hashable = Partial<Location> & { hash: Hash };
-type Pathable = Partial<Path> & { pathname: Pathname };
-export interface Parser {
-  (to: Location): Location;
-  (to: To): Pathable;
-}
-export interface UseParser {
-  (list: PathRenamer[]): Parser;
-}
-export interface GoAPI {
-  (to: To, state?: any): void;
-}
-export interface ListenAPI {
-  (listener: Listener): VoidFn;
-}
-
-export type WrapperOptions = {
-  decode: Parser;
-  encode: Parser;
-};
-
-export type TranscoderOptions = {
-  hashRoot?: string;
-  hashSlash?: string;
-};
+import type { History } from "history";
+import type { TranscoderOptions } from "./transcoder";
+export type { TranscoderOptions } from "./transcoder";
 
 export type HashOptions = TranscoderOptions & {
   window?: Window;
-};
-
-const createHref = (to: To | Location): Pathname => {
-  return typeof to === "string" ? to : createPath(to);
-};
-
-const isLocation = (to: To | Location): to is Location => {
-  const { key = null } = {
-    ...(typeof to === "object" ? to : {}),
-  };
-  return key !== null;
-};
-
-// Replace all / with custom slashes
-const useParser: UseParser = (list) => {
-  const replace: PathRenamer = (pathname) => {
-    return list.reduce((p, fn) => fn(p), pathname);
-  };
-  function parser(to: Location): Location;
-  function parser(to: To): Pathable;
-  function parser(to: To | Location) {
-    const pathname = replace(createHref(to));
-    return !isLocation(to)
-      ? { pathname }
-      : {
-          pathname,
-          key: to.key,
-          state: to.state,
-          search: "",
-          hash: "",
-        };
-  }
-  return parser;
-};
-
-const transcoder = (root: Pair, slash: Pair, input: string) => {
-  const rest = input.substring(input.indexOf(root[0]) + root[0].length);
-  const prefix = input.match(/^\.\.\//) ? input.split(rest)[0] : root[1];
-  return prefix + rest.replaceAll(...slash);
-};
-
-const useTranscoders = ({
-  hashRoot = "",
-  hashSlash = "/",
-}: TranscoderOptions): WrapperOptions => {
-  const encode = useParser([
-    (t) => transcoder(["/", hashRoot], ["/", hashSlash], t),
-  ]);
-  const decode = useParser([
-    (t) => transcoder([hashRoot, "/"], [hashSlash, "/"], t),
-  ]);
-
-  return {
-    encode,
-    decode,
-  };
-};
-
-const useWarnWrapper = (c: Console) => {
-  const w = c.warn;
-  return (fn: VoidFn) => {
-    c.warn = new Proxy(w, { apply: () => null });
-    c.warn = ((_) => w)(fn());
-  };
-};
-
-const useWrappers = ({ encode, decode }: WrapperOptions) => {
-  return {
-    wrapGo: (fn: GoAPI): GoAPI => {
-      return (to, state) => {
-        return fn(encode(to), state);
-      };
-    },
-    wrapListen: (fn: ListenAPI): ListenAPI => {
-      return (listener) => {
-        return fn(({ action, location }: Update) => {
-          listener({
-            action,
-            location: decode(location),
-          });
-        });
-      };
-    },
-  };
 };
 
 const useHashHistory = ({
@@ -134,42 +27,26 @@ const useHashHistory = ({
   ...config
 }: HashOptions = {}): History => {
   const core = useWrappers(useTranscoders(config));
-  const history = createHashHistory({ window });
-  const wrapGo = new Proxy(core.wrapGo, {
-    apply: (go, _, [fn]) => {
-      return go((to, state) => {
-        useWarnWrapper(console)(() => fn(to, state));
-      });
+  const windowProxy = new Proxy(window, {
+    get: (_, prop) => {
+      const v = getProperty(window, prop);
+      return inWrappers(prop) ? core[prop](v) : v;
     },
   });
+  const history = createHashHistory({ window: windowProxy });
 
   return new Proxy(history, {
-    get: (target, prop, _) => {
-      switch (prop) {
-        case "push":
-          return wrapGo(target.push);
-        case "replace":
-          return wrapGo(target.replace);
-        case "listen":
-          return core.wrapListen(target.listen);
-        default:
-          return Reflect.get(target, prop, _);
-      }
+    get: (target, prop) => {
+      const v = Reflect.get(target, prop);
+      return prop in
+        {
+          push: 1,
+          replace: 1,
+        }
+        ? wrapWarn(v)
+        : v;
     },
   });
 };
 
-const useHashParser = (options: TranscoderOptions) => {
-  const { decode } = useTranscoders(options);
-  return (path: Hashable) => {
-    return decode(path.hash.slice(1));
-  };
-};
-
-export {
-  useParser,
-  useWrappers,
-  useTranscoders,
-  useHashHistory,
-  useHashParser,
-};
+export { useTranscoders, useHashHistory };

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -1,0 +1,44 @@
+import { createPath } from "history";
+
+// Types
+import type { To, Update, Listener } from "history";
+import type { Parser } from "./parser";
+
+export interface GoAPI {
+  (to: To, state?: any): void;
+}
+export interface ListenAPI {
+  (listener: Listener): () => void;
+}
+
+const useOldWrappers = ({
+  encode,
+  decode,
+}: {
+  encode: Parser;
+  decode: Parser;
+}) => {
+  return {
+    wrapGo: (fn: GoAPI): GoAPI => {
+      return (to, state) => {
+        const pathname = typeof to === "string" ? to : createPath(to);
+        return fn(encode(pathname), state);
+      };
+    },
+    wrapListen: (fn: ListenAPI): ListenAPI => {
+      return (listener) => {
+        return fn(({ action, location }: Update) => {
+          listener({
+            action,
+            location: {
+              ...location,
+              pathname: decode(location.pathname),
+            },
+          });
+        });
+      };
+    },
+  };
+};
+
+export { useOldWrappers };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,19 @@
+// Types
+type Renamer = (s: string) => string;
+
+export interface Parser {
+  (to: string): string;
+}
+export interface UseParser {
+  (list: Renamer[]): Parser;
+}
+
+// Replace all / with custom slashes
+const useParser: UseParser = (list) => {
+  const parser = (hash: string): string => {
+    return list.reduce((p, fn) => fn(p), hash);
+  };
+  return parser;
+};
+
+export { useParser };

--- a/src/transcoder.ts
+++ b/src/transcoder.ts
@@ -1,0 +1,46 @@
+import { useParser } from "./parser";
+
+// Types
+import type { Hash, Location } from "history";
+import type { WrapperOptions } from "./wrapper";
+
+type Pair = [string, string];
+type Hashable = Partial<Location> & { hash: Hash };
+
+export type TranscoderOptions = {
+  hashRoot?: string;
+  hashSlash?: string;
+};
+
+const transcoder = (root: Pair, slash: Pair, input: string) => {
+  const rest = input.substring(input.indexOf(root[0]) + root[0].length);
+  const prefix = input.match(/^\.\.\//) ? input.split(rest)[0] : root[1];
+  return prefix + rest.replaceAll(...slash);
+};
+
+const useTranscoders = ({
+  hashRoot = "",
+  hashSlash = "/",
+}: TranscoderOptions): WrapperOptions => {
+  const encode = useParser([
+    (t) => transcoder(["/", hashRoot], ["/", hashSlash], t),
+  ]);
+  const decode = useParser([
+    (t) => transcoder([hashRoot, "/"], [hashSlash, "/"], t),
+  ]);
+
+  return {
+    encode,
+    decode,
+  };
+};
+
+// Remove unused function in next major release
+const useHashParser = (options: TranscoderOptions) => {
+  const { decode } = useTranscoders(options);
+  return (path: Hashable) => {
+    return decode(path.hash.slice(1));
+  };
+};
+
+export { useTranscoders, useHashParser };

--- a/src/warn.ts
+++ b/src/warn.ts
@@ -1,0 +1,14 @@
+type F = (..._: any[]) => unknown;
+
+const wrapWarn = (fn: F): F => {
+  return (..._) => {
+    const w = console.warn;
+    const hide = { apply: () => null };
+    console.warn = new Proxy(w, hide);
+    const output = fn(..._);
+    console.warn = w;
+    return output;
+  };
+};
+
+export { wrapWarn };

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,0 +1,80 @@
+import { parsePath, createPath } from "history";
+
+// Types
+import type { Parser } from "./parser";
+
+export type WrapperOptions = {
+  decode: Parser;
+  encode: Parser;
+};
+
+type StateArgs = [any, string, (URL | string)?];
+type StateFunction = (..._: StateArgs) => unknown;
+type Scope = Partial<Omit<Window, number> & History>;
+
+// Old wrappers to remove in next major release
+import { useOldWrappers } from "./legacy";
+
+const parse = (fn: Parser, s = "") => {
+  return `#${fn(s.slice(1))}`;
+};
+
+const getProperty = (scope: Scope, k: string | symbol) => {
+  const v = scope[k as keyof Scope];
+  return typeof v === "function" ? v.bind(scope) : v;
+};
+
+type ProxyCore = "history" | "location";
+function inWrappers(x: string | symbol): x is ProxyCore {
+  return (
+    x in
+    {
+      history: 1,
+      location: 1,
+    }
+  );
+}
+
+function inHistoryWrapper(x: string | symbol): boolean {
+  return (
+    x in
+    {
+      pushState: 1,
+      replaceState: 1,
+    }
+  );
+}
+
+const makeArgsEncoder = (encode: Parser) => {
+  return (fn: StateFunction) => {
+    return (...[_s, _t, url]: StateArgs) => {
+      const path = parsePath((url || "").toString());
+      const hash = parse(encode, path.hash);
+      return fn(_s, _t, createPath({ ...path, hash }));
+    };
+  };
+};
+
+const useWrappers = ({ encode, decode }: WrapperOptions) => {
+  const encodeArgs = makeArgsEncoder(encode);
+
+  return {
+    ...useOldWrappers({ encode, decode }),
+    history: (globalHistory: History): History => {
+      return new Proxy(globalHistory, {
+        get: (_, prop) => {
+          const v = getProperty(globalHistory, prop);
+          return inHistoryWrapper(prop) ? encodeArgs(v) : v;
+        },
+      });
+    },
+    location: (location: Location): Location => {
+      return {
+        ...location,
+        hash: parse(decode, location.hash),
+      };
+    },
+  };
+};
+
+export { useWrappers, inWrappers, getProperty };


### PR DESCRIPTION
This closes #9. 

With all features of `use-hash-history` moved to a `window` proxy, the `history` library should behave exactly the same internally whether or not `use-hash-history` is involved at all.

All features of `use-hash-history` now exist at the interface of `history` and `window`.